### PR TITLE
Fixed the pattern count bug fix in case of multiprocessing

### DIFF
--- a/src/parallel_clusterer.rs
+++ b/src/parallel_clusterer.rs
@@ -123,12 +123,12 @@ fn merge(
             );
 
             if score <= options.max_dist {
-                cluster_b.count += 1;
+                cluster_b.count += cluster_a.count;
 
                 let pattern_b = std::mem::take(&mut cluster_b.pattern);
 
                 cluster_b.pattern = cluster_a.pattern.merge(pattern_b);
-                return;
+                break;
             }
         }
 


### PR DESCRIPTION
@lily-mara thanks for creating this library.

I have also used this library in one of our projects, which has solved a significant problem of finding patterns in logs.

However, while working on this I found line count with the placeholder had a lesser count with multiprocessing. After digging I found a minor issue in the code. Hence raising this PR. Please review and let me know your views.